### PR TITLE
Fix of Bad Request

### DIFF
--- a/bot/core/tapper.py
+++ b/bot/core/tapper.py
@@ -296,7 +296,7 @@ class Tapper:
 
                         if settings.AUTO_UPGRADE is True:
                             upgrades = await self.get_upgrades(http_client=http_client)
-                            available_upgrades = [data for data in upgrades if data['isAvailable'] is True]
+                            available_upgrades = [data for data in upgrades if data['isAvailable'] is True and data['isExpired'] is False]
 
                             for upgrade in available_upgrades:
                                 upgrade_id = upgrade['id']
@@ -310,6 +310,7 @@ class Tapper:
                                     status = await self.buy_upgrade(http_client=http_client, upgrade_id=upgrade_id)
                                     if status is True:
                                         earn_on_hour += profit
+                                        balance -= price
                                         logger.success(
                                             f"{self.session_name} | "
                                             f"Successfully upgraded <e>{upgrade_id}</e> to <m>{level}</m> lvl | "


### PR DESCRIPTION
EN:
Covers only **buying upgrades** error.
Fix of the Bad Request error. It occurred for the following reasons:
1. The price was not updated after purchasing the upgrade. For this reason, the upgrade was considered available, but there was no money to buy it, but the program still sent a request to buy it.
2. Unavailable cards from the Specials section were marked as available by the program, although this is not the case.

RU:
Касается только ошибки **покупки улучшений**.
Исправление ошибки Bad Request. Она происходила по следующим причинам:
1. Цена не обновлялась после покупки улучшения. По этой причине улучшение считалось доступным, но денег на его покупку не было, но программа все равно отправляла запрос на его покупку.
2. Недоступные карточки из раздела Specials отмечались программой как доступные, хотя это не так.