### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@ FROM python:3.11.9-slim as builder
 LABEL org.opencontainers.image.source=https://github.com/shamhi/HamsterKombatBot
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y \
+    gcc \
+    build-essential \
+    libssl-dev \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip3 install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
fix: error: subprocess-exited-with-error
  
  × Building wheel for TgCrypto (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [22 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.linux-aarch64-cpython-311
      creating build/lib.linux-aarch64-cpython-311/tests
      copying tests/__init__.py -> build/lib.linux-aarch64-cpython-311/tests
      creating build/lib.linux-aarch64-cpython-311/tests/ige
      copying tests/ige/__init__.py -> build/lib.linux-aarch64-cpython-311/tests/ige
      copying tests/ige/test_ige.py -> build/lib.linux-aarch64-cpython-311/tests/ige
      creating build/lib.linux-aarch64-cpython-311/tests/ctr
      copying tests/ctr/__init__.py -> build/lib.linux-aarch64-cpython-311/tests/ctr
      copying tests/ctr/test_ctr.py -> build/lib.linux-aarch64-cpython-311/tests/ctr
      creating build/lib.linux-aarch64-cpython-311/tests/cbc
      copying tests/cbc/__init__.py -> build/lib.linux-aarch64-cpython-311/tests/cbc
      copying tests/cbc/test_cbc.py -> build/lib.linux-aarch64-cpython-311/tests/cbc
      running build_ext
      building 'tgcrypto' extension
      creating build/temp.linux-aarch64-cpython-311
      creating build/temp.linux-aarch64-cpython-311/tgcrypto
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.11 -c tgcrypto/aes256.c -o build/temp.linux-aarch64-cpython-311/tgcrypto/aes256.o
      error: command 'gcc' failed: No such file or directory
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for TgCrypto
Successfully built pyaes
Failed to build TgCrypto
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (TgCrypto)
The command '/bin/sh -c pip3 install --upgrade pip setuptools wheel &&     pip3 install --no-cache-dir -r requirements.txt' returned a non-zero code: 1
ERROR: Service 'bot' failed to build : Build failed