### PR TITLE
Fixing dependency installation for Chromium in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt .
 RUN pip3 install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir -r requirements.txt
 
-RUN playwright install --with-deps
+RUN playwright install chromium
 
 FROM python:3.11.9-slim
 
@@ -21,4 +21,8 @@ WORKDIR /app
 
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=builder /root/.cache/ms-playwright /root/.cache/ms-playwright
+
+RUN python -m playwright install-deps chromium && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,13 @@ COPY requirements.txt .
 RUN pip3 install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir -r requirements.txt
 
-RUN playwright install chromium
-
 FROM python:3.11.9-slim
 
 WORKDIR /app
 
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-COPY --from=builder /root/.cache/ms-playwright /root/.cache/ms-playwright
 
-RUN python -m playwright install-deps chromium && \
+RUN python -m playwright install --with-deps chromium && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . .


### PR DESCRIPTION
There is no point in loading dependencies into Builder, otherwise Chromium will refuse to start due to their absence. 