### PR TITLE
Fixed usage of floating time on APIs

### DIFF
--- a/bot/api/boosts.py
+++ b/bot/api/boosts.py
@@ -28,7 +28,7 @@ async def apply_boost(
         http_client,
         'POST',
         'https://api.hamsterkombatgame.io/clicker/buy-boost',
-        {'timestamp': time(), 'boostId': boost_id},
+        {'timestamp': int(time()), 'boostId': boost_id},
         'Apply Boost',
     )
 

--- a/bot/api/clicker.py
+++ b/bot/api/clicker.py
@@ -72,7 +72,7 @@ async def send_taps(
         {
             'availableTaps': available_energy,
             'count': taps,
-            'timestamp': time(),
+            'timestamp': int(time()),
         },
         'Tapping',
         ignore_status=422,

--- a/bot/api/upgrades.py
+++ b/bot/api/upgrades.py
@@ -27,7 +27,7 @@ async def buy_upgrade(
         http_client,
         'POST',
         'https://api.hamsterkombatgame.io/clicker/buy-upgrade',
-        {'timestamp': time(), 'upgradeId': upgrade_id},
+        {'timestamp': int(time()), 'upgradeId': upgrade_id},
         'buying Upgrade',
         ignore_status=422,
     )


### PR DESCRIPTION
Usage of float time causes error with the call of APIs. Using the integer value fixes the response.

![image](https://github.com/user-attachments/assets/996ab8a8-5c0f-4125-929c-f27e9a8ce95a)


Closed #2139