### PR TITLE
Changed default value of MAX_COMBO_PRICE

### DIFF
--- a/bot/config/config.py
+++ b/bot/config/config.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     BALANCE_TO_SAVE: int = 1000000
     UPGRADES_COUNT: int = 10
 
-    MAX_COMBO_PRICE: int = 10000000
+    MAX_COMBO_PRICE: int = 2500000
 
     APPLY_COMBO: bool = True
     APPLY_PROMO_CODES: bool = True


### PR DESCRIPTION
Since the maximum daily reward for combos is currently 5_000_000, I think a reasonable default value should earn at least 50% of the expense. Previously it was 10_000_000 which is too expensive!