### PR TITLE
FIX Infinite loop when getting promo code

### DIFF
--- a/bot/core/tapper.py
+++ b/bot/core/tapper.py
@@ -348,7 +348,7 @@ class Tapper:
                                                                   proxy=proxy)
 
                                 if not promo_code:
-                                    continue
+                                    break
 
                                 profile_data, promo_state = await apply_promo(http_client=http_client,
                                                                               promo_code=promo_code)


### PR DESCRIPTION
When a promo code from a game cannot be acquired in "max_attempts" times, loop restarts and bot tries to get promo code from the same game. Fix provided here ensures that when bot exhausts all attempts, it skips to another game