### PR TITLE
Fix daily combo

### DIFF
--- a/bot/core/tapper.py
+++ b/bot/core/tapper.py
@@ -158,7 +158,7 @@ class Tapper:
 
                             if start_bonus_round <= datetime.now() < end_bonus_round:
                                 common_price = sum([upgrade['price'] for upgrade in available_combo_cards])
-                                need_cards_count = len(cards)
+                                need_cards_count = 3 - len(upgraded_list)
                                 possible_cards_count = len(available_combo_cards)
                                 is_combo_accessible = need_cards_count == possible_cards_count
 


### PR DESCRIPTION
Fixed a logical error that prevented the daily combo combo from being purchased if one of the cards had already been purchased